### PR TITLE
main: snprintf is changed to fmp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,10 @@ jobs:
         ref: main
         path: CI
 
+    - name: Install lib
+      run: |
+        sudo apt-get install libfmt-dev
+
     - name: Build Commit branch
       run: |
         cd $GITHUB_WORKSPACE
@@ -106,6 +110,10 @@ jobs:
         repository: ${{ github.repository }}
         ref: main
         path: CI
+
+    - name: Install lib
+      run: |
+        sudo apt-get install libfmt-dev
 
     - name: Build Commit branch
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = g++  
-CXXFLAGS = -std=c++11 -Wextra -pedantic -pthread -Wall -O3
+CXXFLAGS = -std=c++17 -Wextra -pedantic -pthread -Wall -O3
 
 PROM = bin2ddr  
   
@@ -32,10 +32,9 @@ else
 CXXFLAGS += -DMAX_FILE=4
 endif
 
-LDFLAGS =-L. -lz -lzstd
+LDFLAGS =-L. -lz -lzstd -lfmt
 # 使用 -I 选项指定头文件搜索路径  
 CPPFLAGS = -I$(INCDIR)  
-  
 # 指定对象文件的目录  
 VPATH = $(SRCDIR):$(OBJDIR)  
   

--- a/csrc/main.cpp
+++ b/csrc/main.cpp
@@ -238,7 +238,7 @@ void thread_write_files(const int ch) {
             while (!memory_queues[ch].empty()) {
               this_memory = memory_queues[ch].front();
               memory_queues[ch].pop();
-              buffer += fmt::format("@{:x} {:016x}\n", this_memory.addr * sizeof(uint64_t), this_memory.data);
+              buffer += fmt::format("@{:x} {:016x}\n", this_memory.addr, this_memory.data);
             }
           #endif
         }
@@ -249,7 +249,7 @@ void thread_write_files(const int ch) {
           #ifdef USE_FPGA
             buffer += fmt::format("{:x}\n{:016x}\n", this_memory.addr * sizeof(uint64_t), this_memory.data);
           #else
-            buffer += fmt::format("@{:x} {:016x}\n", this_memory.addr * sizeof(uint64_t), this_memory.data);
+            buffer += fmt::format("@{:x} {:016x}\n", this_memory.addr, this_memory.data);
           #endif
         }
       }


### PR DESCRIPTION
This will reduce the memory footprint of the program and speed up the format conversion slightly. 
Use apt-get install libfmt-dev to install the library